### PR TITLE
Update the version of `x86_64` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ exclude = [
 ]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = "0.11.7"
+x86_64 = "0.12.1"


### PR DESCRIPTION
To fix the build error. See: https://github.com/rust-osdev/x86_64/pull/182