### PR TITLE
chore: remove the `const_panic` feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@
 
 #![deny(missing_docs)]
 #![feature(asm)]
-#![feature(const_panic)]
 #![no_std]
 
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
It's now on stable.
