### PR TITLE
fix: build error on the latest nightly

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -5,6 +5,7 @@
 //! AArch64.
 
 use crate::QEMUExit;
+use core::arch::asm;
 
 const EXIT_SUCCESS: u32 = 0;
 const EXIT_FAILURE: u32 = 1;

--- a/src/riscv64.rs
+++ b/src/riscv64.rs
@@ -5,6 +5,7 @@
 //! RISCV64.
 
 use crate::QEMUExit;
+use core::arch::asm;
 
 const EXIT_SUCCESS: u32 = 0x5555; // Equals `exit(0)`.
 

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -5,6 +5,7 @@
 //! x86.
 
 use crate::QEMUExit;
+use core::arch::asm;
 
 const EXIT_FAILURE: u32 = 0; // since ((0 << 1) | 1) = 1.
 

--- a/tests/aarch64_raspi3/mod.rs
+++ b/tests/aarch64_raspi3/mod.rs
@@ -4,6 +4,8 @@
 
 //! AArch64 specific setup code.
 
+use core::arch::asm;
+
 #[no_mangle]
 unsafe fn _start() -> ! {
     asm!("mov sp, #0x80000");

--- a/tests/riscv64_virt/mod.rs
+++ b/tests/riscv64_virt/mod.rs
@@ -4,6 +4,8 @@
 
 //! RISCV64 specific setup code.
 
+use core::arch::asm;
+
 #[no_mangle]
 unsafe fn _start() -> ! {
     asm!("la sp, _stack");


### PR DESCRIPTION
`asm!` is excluded from Prelude.
