### PR TITLE
x86, riscv64: mark constructors as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved the repository to [rust-embedded](https://github.com/rust-embedded) under the libs team.
+- Changed `X86::new` and `RISCV64::new` to unsafe.
 
 [Unreleased]: https://github.com/rust-embedded/qemu-exit/compare/v3.0.2...HEAD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,12 @@
 //!
 //! // addr: The address of sifive_test.
 //! #[cfg(target_arch = "riscv64")]
-//! let qemu_exit_handle = qemu_exit::RISCV64::new(addr);
+//! let qemu_exit_handle = unsafe { qemu_exit::RISCV64::new(addr) };
 //!
 //! // io_base:             I/O-base of isa-debug-exit.
 //! // custom_exit_success: A custom success code; Must be an odd number.
 //! #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-//! let qemu_exit_handle = qemu_exit::X86::new(io_base, custom_exit_success);
+//! let qemu_exit_handle = unsafe { qemu_exit::X86::new(io_base, custom_exit_success) };
 //!
 //! qemu_exit_handle.exit(1337);
 //! qemu_exit_handle.exit_success();
@@ -74,7 +74,7 @@
 //! possible to let QEMU invoke `exit(0)`.
 //!
 //! ```ignore
-//! let qemu_exit_handle = qemu_exit::X86::new(io_base, custom_exit_success);
+//! let qemu_exit_handle = unsafe { qemu_exit::X86::new(io_base, custom_exit_success) };
 //! ```
 //!
 //! ## Literature

--- a/src/riscv64.rs
+++ b/src/riscv64.rs
@@ -26,7 +26,11 @@ const fn exit_code_encode(code: u32) -> u32 {
 
 impl RISCV64 {
     /// Create an instance.
-    pub const fn new(addr: u64) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// The provided `addr` must be the address of the qemu `sifive_test` device.
+    pub const unsafe fn new(addr: u64) -> Self {
         RISCV64 { addr }
     }
 }

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -33,7 +33,12 @@ fn outl(io_base: u16, code: u32) {
 
 impl X86 {
     /// Create an instance.
-    pub const fn new(io_base: u16, custom_exit_success: u32) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// The provided `io_base` must match the `io_base` given to qemu for the `isa-debug-exit`
+    /// device.
+    pub const unsafe fn new(io_base: u16, custom_exit_success: u32) -> Self {
         assert!((custom_exit_success & 1) == 1);
 
         X86 {

--- a/tests/exit_13.rs
+++ b/tests/exit_13.rs
@@ -35,7 +35,7 @@ mod armv7m_mps2an500;
 //--------------------------------------------------------------------------------------------------
 
 #[cfg(target_arch = "riscv64")]
-const QEMU_EXIT_HANDLE: qemu_exit::RISCV64 = qemu_exit::RISCV64::new(0x100000);
+const QEMU_EXIT_HANDLE: qemu_exit::RISCV64 = unsafe { qemu_exit::RISCV64::new(0x100000) };
 
 #[cfg(target_arch = "riscv64")]
 mod riscv64_virt;
@@ -45,7 +45,7 @@ mod riscv64_virt;
 //--------------------------------------------------------------------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-const QEMU_EXIT_HANDLE: qemu_exit::X86 = qemu_exit::X86::new(0xf4, 5);
+const QEMU_EXIT_HANDLE: qemu_exit::X86 = unsafe { qemu_exit::X86::new(0xf4, 5) };
 
 //--------------------------------------------------------------------------------------------------
 // Generic code


### PR DESCRIPTION
Fixes: #35
Requires: #39, #37

This is missing `# Safety` docstrings, if someone has the time to read the ISA's and document what criteria needs to be met for safe usage feel free to push to this branch.